### PR TITLE
Possibility to add Custom Scatter Shape 

### DIFF
--- a/MPChartExample/src/com/xxmassdeveloper/mpchartexample/ScatterChartActivity.java
+++ b/MPChartExample/src/com/xxmassdeveloper/mpchartexample/ScatterChartActivity.java
@@ -1,7 +1,6 @@
 
 package com.xxmassdeveloper.mpchartexample;
 
-import android.graphics.Color;
 import android.graphics.Typeface;
 import android.os.Bundle;
 import android.util.Log;
@@ -13,7 +12,6 @@ import android.widget.SeekBar.OnSeekBarChangeListener;
 import android.widget.TextView;
 
 import com.github.mikephil.charting.charts.ScatterChart;
-import com.github.mikephil.charting.charts.ScatterChart.ScatterShape;
 import com.github.mikephil.charting.components.Legend;
 import com.github.mikephil.charting.components.Legend.LegendPosition;
 import com.github.mikephil.charting.components.XAxis;
@@ -21,11 +19,10 @@ import com.github.mikephil.charting.components.YAxis;
 import com.github.mikephil.charting.data.Entry;
 import com.github.mikephil.charting.data.ScatterData;
 import com.github.mikephil.charting.data.ScatterDataSet;
-import com.github.mikephil.charting.data.filter.Approximator;
-import com.github.mikephil.charting.data.filter.Approximator.ApproximatorType;
 import com.github.mikephil.charting.highlight.Highlight;
 import com.github.mikephil.charting.interfaces.datasets.IScatterDataSet;
 import com.github.mikephil.charting.listener.OnChartValueSelectedListener;
+import com.github.mikephil.charting.renderer.ShapeRenders.ScatterShape;
 import com.github.mikephil.charting.utils.ColorTemplate;
 import com.xxmassdeveloper.mpchartexample.notimportant.DemoBase;
 
@@ -191,15 +188,15 @@ public class ScatterChartActivity extends DemoBase implements OnSeekBarChangeLis
 
         // create a dataset and give it a type
         ScatterDataSet set1 = new ScatterDataSet(yVals1, "DS 1");
-        set1.setScatterShape(ScatterShape.SQUARE);
+        set1.setScatterShape(ScatterShape.getScatterShapeNames().get(ScatterShape.SQUARE));
         set1.setColor(ColorTemplate.COLORFUL_COLORS[0]);
         ScatterDataSet set2 = new ScatterDataSet(yVals2, "DS 2");
-        set2.setScatterShape(ScatterShape.CIRCLE);
+        set2.setScatterShape(ScatterShape.getScatterShapeNames().get(ScatterShape.CIRCLE));
         set2.setScatterShapeHoleColor(ColorTemplate.COLORFUL_COLORS[3]);
         set2.setScatterShapeHoleRadius(4f);
         set2.setColor(ColorTemplate.COLORFUL_COLORS[1]);
         ScatterDataSet set3 = new ScatterDataSet(yVals3, "DS 3");
-        set3.setScatterShape(ScatterShape.CROSS);
+        set3.setScatterShape(ScatterShape.getScatterShapeNames().get(ScatterShape.CROSS));
         set3.setColor(ColorTemplate.COLORFUL_COLORS[2]);
 
         set1.setScatterShapeSize(8f);

--- a/MPChartExample/src/com/xxmassdeveloper/mpchartexample/fragments/SimpleFragment.java
+++ b/MPChartExample/src/com/xxmassdeveloper/mpchartexample/fragments/SimpleFragment.java
@@ -8,8 +8,6 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
-import com.github.mikephil.charting.charts.ScatterChart;
-import com.github.mikephil.charting.charts.ScatterChart.ScatterShape;
 import com.github.mikephil.charting.data.BarData;
 import com.github.mikephil.charting.data.BarDataSet;
 import com.github.mikephil.charting.data.BarEntry;
@@ -24,6 +22,7 @@ import com.github.mikephil.charting.data.ScatterDataSet;
 import com.github.mikephil.charting.interfaces.datasets.IBarDataSet;
 import com.github.mikephil.charting.interfaces.datasets.ILineDataSet;
 import com.github.mikephil.charting.interfaces.datasets.IScatterDataSet;
+import com.github.mikephil.charting.renderer.ShapeRenders.ScatterShape;
 import com.github.mikephil.charting.utils.ColorTemplate;
 import com.github.mikephil.charting.utils.FileUtils;
 
@@ -71,7 +70,7 @@ public abstract class SimpleFragment extends Fragment {
         
         ArrayList<IScatterDataSet> sets = new ArrayList<IScatterDataSet>();
         
-        ScatterShape[] shapes = ScatterChart.getAllPossibleShapes();
+        String[] shapes = ScatterShape.getAllPossibleShapes();
         
         for(int i = 0; i < dataSets; i++) {
            

--- a/MPChartExample/src/com/xxmassdeveloper/mpchartexample/realm/RealmDatabaseActivityScatter.java
+++ b/MPChartExample/src/com/xxmassdeveloper/mpchartexample/realm/RealmDatabaseActivityScatter.java
@@ -8,6 +8,7 @@ import com.github.mikephil.charting.charts.ScatterChart;
 import com.github.mikephil.charting.data.realm.implementation.RealmScatterData;
 import com.github.mikephil.charting.data.realm.implementation.RealmScatterDataSet;
 import com.github.mikephil.charting.interfaces.datasets.IScatterDataSet;
+import com.github.mikephil.charting.renderer.ShapeRenders.ScatterShape;
 import com.github.mikephil.charting.utils.ColorTemplate;
 import com.xxmassdeveloper.mpchartexample.R;
 import com.xxmassdeveloper.mpchartexample.custom.RealmDemoData;
@@ -57,7 +58,7 @@ public class RealmDatabaseActivityScatter extends RealmBaseActivity {
         set.setLabel("Realm ScatterDataSet");
         set.setScatterShapeSize(9f);
         set.setColor(ColorTemplate.rgb("#CDDC39"));
-        set.setScatterShape(ScatterChart.ScatterShape.CIRCLE);
+        set.setScatterShape(ScatterShape.getScatterShapeNames().get(ScatterShape.CIRCLE));
 
         ArrayList<IScatterDataSet> dataSets = new ArrayList<IScatterDataSet>();
         dataSets.add(set); // add the dataset

--- a/MPChartLib/src/com/github/mikephil/charting/charts/ScatterChart.java
+++ b/MPChartLib/src/com/github/mikephil/charting/charts/ScatterChart.java
@@ -7,22 +7,62 @@ import android.util.AttributeSet;
 import com.github.mikephil.charting.data.ScatterData;
 import com.github.mikephil.charting.interfaces.dataprovider.ScatterDataProvider;
 import com.github.mikephil.charting.renderer.ScatterChartRenderer;
+import com.github.mikephil.charting.renderer.ShapeRenders.ChevronDownShapeRenderer;
+import com.github.mikephil.charting.renderer.ShapeRenders.ChevronUpShapeRenderer;
+import com.github.mikephil.charting.renderer.ShapeRenders.CircleShapeRenderer;
+import com.github.mikephil.charting.renderer.ShapeRenders.CrossShapeRenderer;
+import com.github.mikephil.charting.renderer.ShapeRenders.ScatterShape;
+import com.github.mikephil.charting.renderer.ShapeRenders.ShapeRenderer;
+import com.github.mikephil.charting.renderer.ShapeRenders.SquareShapeRenderer;
+import com.github.mikephil.charting.renderer.ShapeRenders.TriangleShapeRenderer;
+import com.github.mikephil.charting.renderer.ShapeRenders.XShapeRenderer;
+
+import java.util.HashMap;
 
 /**
  * The ScatterChart. Draws dots, triangles, squares and custom shapes into the
  * Chart-View. CIRCLE and SCQUARE offer the best performance, TRIANGLE has the
  * worst performance.
- * 
+ *
  * @author Philipp Jahoda
  */
 public class ScatterChart extends BarLineChartBase<ScatterData> implements ScatterDataProvider {
 
+
     /**
-     * enum that defines the shape that is drawn where the values are
+     * Dictionary of ShapeRenderer which are responsible for drawing custom shapes.
+     * Can add to it your custom shapes.
+     * CustomShapeRenderer Implements ShapeRenderer{}
      */
-    public enum ScatterShape {
-        SQUARE, CIRCLE, TRIANGLE, CROSS, X,
+    private static HashMap<String, ShapeRenderer> shapeRendererList;
+
+    public static void registerShapeRenderer(String scatterShapeName, ShapeRenderer shapeRenderer) {
+        if (shapeRendererList == null) {
+            shapeRendererList = new HashMap<>();
+        }
+        shapeRendererList.put(scatterShapeName, shapeRenderer);
     }
+
+    public static ShapeRenderer getShapeRenderer(String scatterShapeName) {
+        if (shapeRendererList == null) {
+            initShapeRenderer();
+        }
+        return shapeRendererList.get(scatterShapeName);
+    }
+
+    /**
+     * Init ShapeRendererList
+     */
+    private static void initShapeRenderer() {
+        registerShapeRenderer(ScatterShape.getScatterShapeNames().get(ScatterShape.SQUARE), new SquareShapeRenderer());
+        registerShapeRenderer(ScatterShape.getScatterShapeNames().get(ScatterShape.CIRCLE), new CircleShapeRenderer());
+        registerShapeRenderer(ScatterShape.getScatterShapeNames().get(ScatterShape.TRIANGLE), new TriangleShapeRenderer());
+        registerShapeRenderer(ScatterShape.getScatterShapeNames().get(ScatterShape.CROSS), new CrossShapeRenderer());
+        registerShapeRenderer(ScatterShape.getScatterShapeNames().get(ScatterShape.X), new XShapeRenderer());
+        registerShapeRenderer(ScatterShape.getScatterShapeNames().get(ScatterShape.CHEVRON_UP), new ChevronUpShapeRenderer());
+        registerShapeRenderer(ScatterShape.getScatterShapeNames().get(ScatterShape.CHEVRON_DOWN), new ChevronDownShapeRenderer());
+    }
+
 
     public ScatterChart(Context context) {
         super(context);
@@ -35,6 +75,7 @@ public class ScatterChart extends BarLineChartBase<ScatterData> implements Scatt
     public ScatterChart(Context context, AttributeSet attrs, int defStyle) {
         super(context, attrs, defStyle);
     }
+
 
     @Override
     protected void init() {
@@ -55,18 +96,10 @@ public class ScatterChart extends BarLineChartBase<ScatterData> implements Scatt
         mXAxis.mAxisRange = Math.abs(mXAxis.mAxisMaximum - mXAxis.mAxisMinimum);
     }
 
-    /**
-     * Returns all possible predefined ScatterShapes.
-     * 
-     * @return
-     */
-    public static ScatterShape[] getAllPossibleShapes() {
-        return new ScatterShape[] {
-                ScatterShape.SQUARE, ScatterShape.CIRCLE, ScatterShape.TRIANGLE, ScatterShape.CROSS
-        };
-    }
 
     public ScatterData getScatterData() {
         return mData;
-    };
+    }
+
+    ;
 }

--- a/MPChartLib/src/com/github/mikephil/charting/data/ScatterDataSet.java
+++ b/MPChartLib/src/com/github/mikephil/charting/data/ScatterDataSet.java
@@ -1,8 +1,8 @@
 
 package com.github.mikephil.charting.data;
 
-import com.github.mikephil.charting.charts.ScatterChart.ScatterShape;
 import com.github.mikephil.charting.interfaces.datasets.IScatterDataSet;
+import com.github.mikephil.charting.renderer.ShapeRenders.ScatterShape;
 import com.github.mikephil.charting.utils.ColorTemplate;
 
 import java.util.ArrayList;
@@ -19,7 +19,7 @@ public class ScatterDataSet extends LineScatterCandleRadarDataSet<Entry> impleme
      * the type of shape that is set to be drawn where the values are at,
      * default ScatterShape.SQUARE
      */
-    private ScatterShape mScatterShape = ScatterShape.SQUARE;
+    private String mScatterShape = ScatterShape.getScatterShapeNames().get(ScatterShape.SQUARE);
 
     /**
      * The radius of the hole in the shape (applies to Square, Circle and Triangle)
@@ -84,12 +84,12 @@ public class ScatterDataSet extends LineScatterCandleRadarDataSet<Entry> impleme
      *
      * @param shape
      */
-    public void setScatterShape(ScatterShape shape) {
+    public void setScatterShape(String shape) {
         mScatterShape = shape;
     }
 
     @Override
-    public ScatterShape getScatterShape() {
+    public String getScatterShape() {
         return mScatterShape;
     }
 

--- a/MPChartLib/src/com/github/mikephil/charting/data/realm/implementation/RealmScatterDataSet.java
+++ b/MPChartLib/src/com/github/mikephil/charting/data/realm/implementation/RealmScatterDataSet.java
@@ -1,13 +1,11 @@
 package com.github.mikephil.charting.data.realm.implementation;
 
-import com.github.mikephil.charting.charts.ScatterChart;
 import com.github.mikephil.charting.data.Entry;
 import com.github.mikephil.charting.data.realm.base.RealmLineScatterCandleRadarDataSet;
 import com.github.mikephil.charting.interfaces.datasets.IScatterDataSet;
+import com.github.mikephil.charting.renderer.ShapeRenders.ScatterShape;
 import com.github.mikephil.charting.utils.ColorTemplate;
-import com.github.mikephil.charting.utils.Utils;
 
-import io.realm.DynamicRealmObject;
 import io.realm.RealmObject;
 import io.realm.RealmResults;
 
@@ -25,7 +23,7 @@ public class RealmScatterDataSet<T extends RealmObject> extends RealmLineScatter
      * the type of shape that is set to be drawn where the values are at,
      * default ScatterShape.SQUARE
      */
-    private ScatterChart.ScatterShape mScatterShape = ScatterChart.ScatterShape.SQUARE;
+    private String mScatterShape = ScatterShape.getScatterShapeNames().get(ScatterShape.SQUARE);
 
     /**
      * The radius of the hole in the shape (applies to Square, Circle and Triangle)
@@ -89,12 +87,12 @@ public class RealmScatterDataSet<T extends RealmObject> extends RealmLineScatter
      *
      * @param shape
      */
-    public void setScatterShape(ScatterChart.ScatterShape shape) {
+    public void setScatterShape(String shape) {
         mScatterShape = shape;
     }
 
     @Override
-    public ScatterChart.ScatterShape getScatterShape() {
+    public String getScatterShape() {
         return mScatterShape;
     }
 

--- a/MPChartLib/src/com/github/mikephil/charting/interfaces/datasets/IScatterDataSet.java
+++ b/MPChartLib/src/com/github/mikephil/charting/interfaces/datasets/IScatterDataSet.java
@@ -1,6 +1,5 @@
 package com.github.mikephil.charting.interfaces.datasets;
 
-import com.github.mikephil.charting.charts.ScatterChart;
 import com.github.mikephil.charting.data.Entry;
 
 /**
@@ -20,7 +19,7 @@ public interface IScatterDataSet extends ILineScatterCandleRadarDataSet<Entry> {
      *
      * @return
      */
-    ScatterChart.ScatterShape getScatterShape();
+    String getScatterShape();
 
     /**
      * Returns radius of the hole in the shape

--- a/MPChartLib/src/com/github/mikephil/charting/renderer/ScatterChartRenderer.java
+++ b/MPChartLib/src/com/github/mikephil/charting/renderer/ScatterChartRenderer.java
@@ -2,18 +2,15 @@
 package com.github.mikephil.charting.renderer;
 
 import android.graphics.Canvas;
-import android.graphics.Paint.Style;
-import android.graphics.Path;
 
 import com.github.mikephil.charting.animation.ChartAnimator;
 import com.github.mikephil.charting.buffer.ScatterBuffer;
-import com.github.mikephil.charting.charts.ScatterChart.ScatterShape;
+import com.github.mikephil.charting.charts.ScatterChart;
 import com.github.mikephil.charting.data.Entry;
 import com.github.mikephil.charting.data.ScatterData;
 import com.github.mikephil.charting.highlight.Highlight;
 import com.github.mikephil.charting.interfaces.dataprovider.ScatterDataProvider;
 import com.github.mikephil.charting.interfaces.datasets.IScatterDataSet;
-import com.github.mikephil.charting.utils.ColorTemplate;
 import com.github.mikephil.charting.utils.Transformer;
 import com.github.mikephil.charting.utils.Utils;
 import com.github.mikephil.charting.utils.ViewPortHandler;
@@ -65,14 +62,9 @@ public class ScatterChartRenderer extends LineScatterCandleRadarRenderer {
         float phaseY = mAnimator.getPhaseY();
 
         final float shapeSize = Utils.convertDpToPixel(dataSet.getScatterShapeSize());
-        final float shapeHalf = shapeSize / 2f;
-        final float shapeHoleSizeHalf = Utils.convertDpToPixel(dataSet.getScatterShapeHoleRadius());
-        final float shapeHoleSize = shapeHoleSizeHalf * 2.f;
         final int shapeHoleColor = dataSet.getScatterShapeHoleColor();
-        final float shapeStrokeSize = (shapeSize - shapeHoleSize) / 2.f;
-        final float shapeStrokeSizeHalf = shapeStrokeSize / 2.f;
 
-        ScatterShape shape = dataSet.getScatterShape();
+        String shape = dataSet.getScatterShape();
 
         ScatterBuffer buffer = mScatterBuffers[mChart.getScatterData().getIndexOfDataSet(
                 dataSet)];
@@ -81,248 +73,10 @@ public class ScatterChartRenderer extends LineScatterCandleRadarRenderer {
 
         trans.pointValuesToPixel(buffer.buffer);
 
-        switch (shape) {
-            case SQUARE:
+        ScatterChart.getShapeRenderer(shape)
+                .renderShape(c, dataSet,mViewPortHandler, buffer, mRenderPaint, shapeHoleColor, shapeSize);
 
-                for (int i = 0; i < buffer.size(); i += 2) {
 
-                    if (!mViewPortHandler.isInBoundsRight(buffer.buffer[i]))
-                        break;
-
-                    if (!mViewPortHandler.isInBoundsLeft(buffer.buffer[i])
-                            || !mViewPortHandler.isInBoundsY(buffer.buffer[i + 1]))
-                        continue;
-
-                    mRenderPaint.setColor(dataSet.getColor(i / 2));
-
-                    if (shapeHoleSize > 0.0) {
-                        mRenderPaint.setStyle(Style.STROKE);
-                        mRenderPaint.setStrokeWidth(shapeStrokeSize);
-
-                        c.drawRect(buffer.buffer[i] - shapeHoleSizeHalf - shapeStrokeSizeHalf,
-                                buffer.buffer[i + 1] - shapeHoleSizeHalf - shapeStrokeSizeHalf,
-                                buffer.buffer[i] + shapeHoleSizeHalf + shapeStrokeSizeHalf,
-                                buffer.buffer[i + 1] + shapeHoleSizeHalf + shapeStrokeSizeHalf,
-                                mRenderPaint);
-
-                        if (shapeHoleColor != ColorTemplate.COLOR_NONE) {
-                            mRenderPaint.setStyle(Style.FILL);
-
-                            mRenderPaint.setColor(shapeHoleColor);
-                            c.drawRect(buffer.buffer[i] - shapeHoleSizeHalf,
-                                    buffer.buffer[i + 1] - shapeHoleSizeHalf,
-                                    buffer.buffer[i] + shapeHoleSizeHalf,
-                                    buffer.buffer[i + 1] + shapeHoleSizeHalf,
-                                    mRenderPaint);
-                        }
-
-                    } else {
-                        mRenderPaint.setStyle(Style.FILL);
-
-                        c.drawRect(buffer.buffer[i] - shapeHalf,
-                                buffer.buffer[i + 1] - shapeHalf,
-                                buffer.buffer[i] + shapeHalf,
-                                buffer.buffer[i + 1] + shapeHalf,
-                                mRenderPaint);
-                    }
-                }
-
-                break;
-
-            case CIRCLE:
-
-                for (int i = 0; i < buffer.size(); i += 2) {
-
-                    if (!mViewPortHandler.isInBoundsRight(buffer.buffer[i]))
-                        break;
-
-                    if (!mViewPortHandler.isInBoundsLeft(buffer.buffer[i])
-                            || !mViewPortHandler.isInBoundsY(buffer.buffer[i + 1]))
-                        continue;
-
-                    mRenderPaint.setColor(dataSet.getColor(i / 2));
-
-                    if (shapeHoleSize > 0.0) {
-                        mRenderPaint.setStyle(Style.STROKE);
-                        mRenderPaint.setStrokeWidth(shapeStrokeSize);
-
-                        c.drawCircle(
-                                buffer.buffer[i],
-                                buffer.buffer[i + 1],
-                                shapeHoleSizeHalf + shapeStrokeSizeHalf,
-                                mRenderPaint);
-
-                        if (shapeHoleColor != ColorTemplate.COLOR_NONE) {
-                            mRenderPaint.setStyle(Style.FILL);
-
-                            mRenderPaint.setColor(shapeHoleColor);
-                            c.drawCircle(
-                                    buffer.buffer[i],
-                                    buffer.buffer[i + 1],
-                                    shapeHoleSizeHalf,
-                                    mRenderPaint);
-                        }
-                    } else {
-                        mRenderPaint.setStyle(Style.FILL);
-
-                        c.drawCircle(
-                                buffer.buffer[i],
-                                buffer.buffer[i + 1],
-                                shapeHalf,
-                                mRenderPaint);
-                    }
-                }
-                break;
-
-            case TRIANGLE:
-
-                mRenderPaint.setStyle(Style.FILL);
-
-                // create a triangle path
-                Path tri = new Path();
-
-                for (int i = 0; i < buffer.size(); i += 2) {
-
-                    if (!mViewPortHandler.isInBoundsRight(buffer.buffer[i]))
-                        break;
-
-                    if (!mViewPortHandler.isInBoundsLeft(buffer.buffer[i])
-                            || !mViewPortHandler.isInBoundsY(buffer.buffer[i + 1]))
-                        continue;
-
-                    mRenderPaint.setColor(dataSet.getColor(i / 2));
-
-                    tri.moveTo(buffer.buffer[i], buffer.buffer[i + 1] - shapeHalf);
-                    tri.lineTo(buffer.buffer[i] + shapeHalf, buffer.buffer[i + 1] + shapeHalf);
-                    tri.lineTo(buffer.buffer[i] - shapeHalf, buffer.buffer[i + 1] + shapeHalf);
-
-                    if (shapeHoleSize > 0.0) {
-                        tri.lineTo(buffer.buffer[i], buffer.buffer[i + 1] - shapeHalf);
-
-                        tri.moveTo(buffer.buffer[i] - shapeHalf + shapeStrokeSize,
-                                buffer.buffer[i + 1] + shapeHalf - shapeStrokeSize);
-                        tri.lineTo(buffer.buffer[i] + shapeHalf - shapeStrokeSize,
-                                buffer.buffer[i + 1] + shapeHalf - shapeStrokeSize);
-                        tri.lineTo(buffer.buffer[i],
-                                buffer.buffer[i + 1] - shapeHalf + shapeStrokeSize);
-                        tri.lineTo(buffer.buffer[i] - shapeHalf + shapeStrokeSize,
-                                buffer.buffer[i + 1] + shapeHalf - shapeStrokeSize);
-                    }
-
-                    tri.close();
-
-                    c.drawPath(tri, mRenderPaint);
-                    tri.reset();
-
-                    if (shapeHoleSize > 0.0 &&
-                            shapeHoleColor != ColorTemplate.COLOR_NONE) {
-
-                        mRenderPaint.setColor(shapeHoleColor);
-
-                        tri.moveTo(buffer.buffer[i],
-                                buffer.buffer[i + 1] - shapeHalf + shapeStrokeSize);
-                        tri.lineTo(buffer.buffer[i] + shapeHalf - shapeStrokeSize,
-                                buffer.buffer[i + 1] + shapeHalf - shapeStrokeSize);
-                        tri.lineTo(buffer.buffer[i] - shapeHalf + shapeStrokeSize,
-                                buffer.buffer[i + 1] + shapeHalf - shapeStrokeSize);
-                        tri.close();
-
-                        c.drawPath(tri, mRenderPaint);
-                        tri.reset();
-                    }
-                }
-                break;
-
-            case CROSS:
-
-                mRenderPaint.setStyle(Style.STROKE);
-                mRenderPaint.setStrokeWidth(Utils.convertDpToPixel(1f));
-
-                for (int i = 0; i < buffer.size(); i += 2) {
-
-                    if (!mViewPortHandler.isInBoundsRight(buffer.buffer[i]))
-                        break;
-
-                    if (!mViewPortHandler.isInBoundsLeft(buffer.buffer[i])
-                            || !mViewPortHandler.isInBoundsY(buffer.buffer[i + 1]))
-                        continue;
-
-                    mRenderPaint.setColor(dataSet.getColor(i / 2));
-
-                    c.drawLine(
-                            buffer.buffer[i] - shapeHalf,
-                            buffer.buffer[i + 1],
-                            buffer.buffer[i] + shapeHalf,
-                            buffer.buffer[i + 1],
-                            mRenderPaint);
-                    c.drawLine(
-                            buffer.buffer[i],
-                            buffer.buffer[i + 1] - shapeHalf,
-                            buffer.buffer[i],
-                            buffer.buffer[i + 1] + shapeHalf,
-                            mRenderPaint);
-                }
-                break;
-
-            case X:
-
-                mRenderPaint.setStyle(Style.STROKE);
-                mRenderPaint.setStrokeWidth(Utils.convertDpToPixel(1f));
-
-                for (int i = 0; i < buffer.size(); i += 2) {
-
-                    if (!mViewPortHandler.isInBoundsRight(buffer.buffer[i]))
-                        break;
-
-                    if (!mViewPortHandler.isInBoundsLeft(buffer.buffer[i])
-                            || !mViewPortHandler.isInBoundsY(buffer.buffer[i + 1]))
-                        continue;
-
-                    mRenderPaint.setColor(dataSet.getColor(i / 2));
-
-                    c.drawLine(
-                            buffer.buffer[i] - shapeHalf,
-                            buffer.buffer[i + 1] - shapeHalf,
-                            buffer.buffer[i] + shapeHalf,
-                            buffer.buffer[i + 1] + shapeHalf,
-                            mRenderPaint);
-                    c.drawLine(
-                            buffer.buffer[i] + shapeHalf,
-                            buffer.buffer[i + 1] - shapeHalf,
-                            buffer.buffer[i] - shapeHalf,
-                            buffer.buffer[i + 1] + shapeHalf,
-                            mRenderPaint);
-                }
-                break;
-
-            default:
-                break;
-        }
-
-        // else { // draw the custom-shape
-        //
-        // Path customShape = dataSet.getCustomScatterShape();
-        //
-        // for (int j = 0; j < entries.size() * mAnimator.getPhaseX(); j += 2) {
-        //
-        // Entry e = entries.get(j / 2);
-        //
-        // if (!fitsBounds(e.getXIndex(), mMinX, mMaxX))
-        // continue;
-        //
-        // if (customShape == null)
-        // return;
-        //
-        // mRenderPaint.setColor(dataSet.getColor(j));
-        //
-        // Path newPath = new Path(customShape);
-        // newPath.offset(e.getXIndex(), e.getVal());
-        //
-        // // transform the provided custom path
-        // trans.pathValueToPixel(newPath);
-        // c.drawPath(newPath, mRenderPaint);
-        // }
-        // }
     }
 
     @Override

--- a/MPChartLib/src/com/github/mikephil/charting/renderer/ShapeRenders/ChevronDownShapeRenderer.java
+++ b/MPChartLib/src/com/github/mikephil/charting/renderer/ShapeRenders/ChevronDownShapeRenderer.java
@@ -1,0 +1,56 @@
+package com.github.mikephil.charting.renderer.ShapeRenders;
+
+import android.graphics.Canvas;
+import android.graphics.Paint;
+
+import com.github.mikephil.charting.buffer.ScatterBuffer;
+import com.github.mikephil.charting.interfaces.datasets.IScatterDataSet;
+import com.github.mikephil.charting.utils.Utils;
+import com.github.mikephil.charting.utils.ViewPortHandler;
+
+/**
+ * Created by wajdic on 15/06/2016.
+ * Created at Time 09:08
+ */
+public class ChevronDownShapeRenderer implements ShapeRenderer {
+
+
+    @Override
+    public void renderShape(
+            Canvas c, IScatterDataSet dataSet,
+            ViewPortHandler mViewPortHandler, ScatterBuffer buffer, Paint mRenderPaint, final int shapeHoleColor, final float shapeSize) {
+
+        final float shapeHalf = shapeSize / 2f;
+
+
+        mRenderPaint.setStyle(Paint.Style.STROKE);
+        mRenderPaint.setStrokeWidth(Utils.convertDpToPixel(1f));
+
+        for (int i = 0; i < buffer.size(); i += 2) {
+
+            if (!mViewPortHandler.isInBoundsRight(buffer.buffer[i]))
+                break;
+
+            if (!mViewPortHandler.isInBoundsLeft(buffer.buffer[i])
+                    || !mViewPortHandler.isInBoundsY(buffer.buffer[i + 1]))
+                continue;
+
+            mRenderPaint.setColor(dataSet.getColor(i / 2));
+
+            c.drawLine(
+                    buffer.buffer[i],
+                    buffer.buffer[i + 1] + (2 * shapeHalf),
+                    buffer.buffer[i] + (2 * shapeHalf),
+                    buffer.buffer[i + 1],
+                    mRenderPaint);
+
+            c.drawLine(
+                    buffer.buffer[i],
+                    buffer.buffer[i + 1] + (2 * shapeHalf),
+                    buffer.buffer[i] - (2 * shapeHalf),
+                    buffer.buffer[i + 1],
+                    mRenderPaint);
+        }
+
+    }
+}

--- a/MPChartLib/src/com/github/mikephil/charting/renderer/ShapeRenders/ChevronUpShapeRenderer.java
+++ b/MPChartLib/src/com/github/mikephil/charting/renderer/ShapeRenders/ChevronUpShapeRenderer.java
@@ -1,0 +1,55 @@
+package com.github.mikephil.charting.renderer.ShapeRenders;
+
+import android.graphics.Canvas;
+import android.graphics.Paint;
+
+import com.github.mikephil.charting.buffer.ScatterBuffer;
+import com.github.mikephil.charting.interfaces.datasets.IScatterDataSet;
+import com.github.mikephil.charting.utils.Utils;
+import com.github.mikephil.charting.utils.ViewPortHandler;
+
+/**
+ * Created by wajdic on 15/06/2016.
+ * Created at Time 09:08
+ */
+public class ChevronUpShapeRenderer implements ShapeRenderer {
+
+
+    @Override
+    public void renderShape(
+            Canvas c, IScatterDataSet dataSet,
+            ViewPortHandler mViewPortHandler, ScatterBuffer buffer, Paint mRenderPaint, final int shapeHoleColor, final float shapeSize) {
+        final float shapeHalf = shapeSize / 2f;
+
+
+        mRenderPaint.setStyle(Paint.Style.STROKE);
+        mRenderPaint.setStrokeWidth(Utils.convertDpToPixel(1f));
+
+        for (int i = 0; i < buffer.size(); i += 2) {
+
+            if (!mViewPortHandler.isInBoundsRight(buffer.buffer[i]))
+                break;
+
+            if (!mViewPortHandler.isInBoundsLeft(buffer.buffer[i])
+                    || !mViewPortHandler.isInBoundsY(buffer.buffer[i + 1]))
+                continue;
+
+            mRenderPaint.setColor(dataSet.getColor(i / 2));
+
+            c.drawLine(
+                    buffer.buffer[i],
+                    buffer.buffer[i + 1] - (2 * shapeHalf),
+                    buffer.buffer[i] + (2 * shapeHalf),
+                    buffer.buffer[i + 1],
+                    mRenderPaint);
+
+            c.drawLine(
+                    buffer.buffer[i],
+                    buffer.buffer[i + 1] - (2 * shapeHalf),
+                    buffer.buffer[i] - (2 * shapeHalf),
+                    buffer.buffer[i + 1],
+                    mRenderPaint);
+        }
+
+    }
+}

--- a/MPChartLib/src/com/github/mikephil/charting/renderer/ShapeRenders/CircleShapeRenderer.java
+++ b/MPChartLib/src/com/github/mikephil/charting/renderer/ShapeRenders/CircleShapeRenderer.java
@@ -1,0 +1,75 @@
+package com.github.mikephil.charting.renderer.ShapeRenders;
+
+import android.graphics.Canvas;
+import android.graphics.Paint;
+
+import com.github.mikephil.charting.buffer.ScatterBuffer;
+import com.github.mikephil.charting.interfaces.datasets.IScatterDataSet;
+import com.github.mikephil.charting.utils.ColorTemplate;
+import com.github.mikephil.charting.utils.Utils;
+import com.github.mikephil.charting.utils.ViewPortHandler;
+
+/**
+ * Created by wajdic on 15/06/2016.
+ * Created at Time 09:08
+ */
+public class CircleShapeRenderer implements ShapeRenderer {
+
+
+    @Override
+    public void renderShape(
+            Canvas c, IScatterDataSet dataSet,
+            ViewPortHandler mViewPortHandler, ScatterBuffer buffer, Paint mRenderPaint, final int shapeHoleColor, final float shapeSize) {
+
+        final float shapeHalf = shapeSize / 2f;
+        final float shapeHoleSizeHalf = Utils.convertDpToPixel(dataSet.getScatterShapeHoleRadius());
+        final float shapeHoleSize = shapeHoleSizeHalf * 2.f;
+        final float shapeStrokeSize = (shapeSize - shapeHoleSize) / 2.f;
+        final float shapeStrokeSizeHalf = shapeStrokeSize / 2.f;
+
+
+        for (int i = 0; i < buffer.size(); i += 2) {
+
+            if (!mViewPortHandler.isInBoundsRight(buffer.buffer[i]))
+                break;
+
+            if (!mViewPortHandler.isInBoundsLeft(buffer.buffer[i])
+                    || !mViewPortHandler.isInBoundsY(buffer.buffer[i + 1]))
+                continue;
+
+            mRenderPaint.setColor(dataSet.getColor(i / 2));
+
+            if (shapeSize > 0.0) {
+                mRenderPaint.setStyle(Paint.Style.STROKE);
+                mRenderPaint.setStrokeWidth(shapeStrokeSize);
+
+                c.drawCircle(
+                        buffer.buffer[i],
+                        buffer.buffer[i + 1],
+                        shapeHoleSizeHalf + shapeStrokeSizeHalf,
+                        mRenderPaint);
+
+                if (shapeHoleColor != ColorTemplate.COLOR_NONE) {
+                    mRenderPaint.setStyle(Paint.Style.FILL);
+
+                    mRenderPaint.setColor(shapeHoleColor);
+                    c.drawCircle(
+                            buffer.buffer[i],
+                            buffer.buffer[i + 1],
+                            shapeHoleSizeHalf,
+                            mRenderPaint);
+                }
+            } else {
+                mRenderPaint.setStyle(Paint.Style.FILL);
+
+                c.drawCircle(
+                        buffer.buffer[i],
+                        buffer.buffer[i + 1],
+                        shapeHalf,
+                        mRenderPaint);
+            }
+        }
+
+    }
+
+}

--- a/MPChartLib/src/com/github/mikephil/charting/renderer/ShapeRenders/CrossShapeRenderer.java
+++ b/MPChartLib/src/com/github/mikephil/charting/renderer/ShapeRenders/CrossShapeRenderer.java
@@ -1,0 +1,55 @@
+package com.github.mikephil.charting.renderer.ShapeRenders;
+
+import android.graphics.Canvas;
+import android.graphics.Paint;
+
+import com.github.mikephil.charting.buffer.ScatterBuffer;
+import com.github.mikephil.charting.interfaces.datasets.IScatterDataSet;
+import com.github.mikephil.charting.utils.Utils;
+import com.github.mikephil.charting.utils.ViewPortHandler;
+
+/**
+ * Created by wajdic on 15/06/2016.
+ * Created at Time 09:08
+ */
+public class CrossShapeRenderer implements ShapeRenderer {
+
+
+    @Override
+    public void renderShape(
+            Canvas c, IScatterDataSet dataSet,
+            ViewPortHandler mViewPortHandler, ScatterBuffer buffer, Paint mRenderPaint, final int shapeHoleColor, final float shapeSize) {
+
+        final float shapeHalf = shapeSize / 2f;
+
+
+        mRenderPaint.setStyle(Paint.Style.STROKE);
+        mRenderPaint.setStrokeWidth(Utils.convertDpToPixel(1f));
+
+        for (int i = 0; i < buffer.size(); i += 2) {
+
+            if (!mViewPortHandler.isInBoundsRight(buffer.buffer[i]))
+                break;
+
+            if (!mViewPortHandler.isInBoundsLeft(buffer.buffer[i])
+                    || !mViewPortHandler.isInBoundsY(buffer.buffer[i + 1]))
+                continue;
+
+            mRenderPaint.setColor(dataSet.getColor(i / 2));
+
+            c.drawLine(
+                    buffer.buffer[i] - shapeHalf,
+                    buffer.buffer[i + 1],
+                    buffer.buffer[i] + shapeHalf,
+                    buffer.buffer[i + 1],
+                    mRenderPaint);
+            c.drawLine(
+                    buffer.buffer[i],
+                    buffer.buffer[i + 1] - shapeHalf,
+                    buffer.buffer[i],
+                    buffer.buffer[i + 1] + shapeHalf,
+                    mRenderPaint);
+        }
+
+    }
+}

--- a/MPChartLib/src/com/github/mikephil/charting/renderer/ShapeRenders/ScatterShape.java
+++ b/MPChartLib/src/com/github/mikephil/charting/renderer/ShapeRenders/ScatterShape.java
@@ -1,0 +1,44 @@
+package com.github.mikephil.charting.renderer.ShapeRenders;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Created by wajdic on 15/06/2016.
+ * Created at Time 10:12
+ */
+public class ScatterShape {
+
+
+    public static final String SQUARE = "SQUARE";
+    public static final String CIRCLE = "CIRCLE";
+    public static final String TRIANGLE = "TRIANGLE";
+    public static final String CROSS = "CROSS";
+    public static final String X = "X";
+    public static final String CHEVRON_UP = "CHEVRON_UP";
+    public static final String CHEVRON_DOWN = "CHEVRON_DOWN";
+
+    private static Map<String, String> scatterShapeNames;
+
+    public static Map<String, String> getScatterShapeNames() {
+        if (scatterShapeNames == null) {
+            scatterShapeNames = new HashMap<>();
+            scatterShapeNames.put(SQUARE, SQUARE);
+            scatterShapeNames.put(CIRCLE, CIRCLE);
+            scatterShapeNames.put(TRIANGLE, TRIANGLE);
+            scatterShapeNames.put(CROSS, CROSS);
+            scatterShapeNames.put(X, X);
+            scatterShapeNames.put(CHEVRON_UP, CHEVRON_UP);
+            scatterShapeNames.put(CHEVRON_DOWN, CHEVRON_DOWN);
+        }
+        return scatterShapeNames;
+    }
+
+    public static String[] getAllPossibleShapes() {
+        String[] possibleShapes = new String[getScatterShapeNames().size()];
+        for (int i = 0; i < getScatterShapeNames().size(); i++) {
+            possibleShapes[i] = getScatterShapeNames().get(i);
+        }
+        return possibleShapes;
+    }
+}

--- a/MPChartLib/src/com/github/mikephil/charting/renderer/ShapeRenders/ShapeRenderer.java
+++ b/MPChartLib/src/com/github/mikephil/charting/renderer/ShapeRenders/ShapeRenderer.java
@@ -1,0 +1,22 @@
+package com.github.mikephil.charting.renderer.ShapeRenders;
+
+import android.graphics.Canvas;
+import android.graphics.Paint;
+
+import com.github.mikephil.charting.buffer.ScatterBuffer;
+import com.github.mikephil.charting.interfaces.datasets.IScatterDataSet;
+import com.github.mikephil.charting.utils.ViewPortHandler;
+
+/**
+ * Created by wajdic on 15/06/2016.
+ * Created at Time 09:07
+ */
+public interface ShapeRenderer {
+
+     void renderShape(
+             Canvas c, IScatterDataSet dataSet,
+             ViewPortHandler mViewPortHandler, ScatterBuffer buffer, Paint mRenderPaint, final int shapeHoleColor, final float shapeSize);
+
+
+
+}

--- a/MPChartLib/src/com/github/mikephil/charting/renderer/ShapeRenders/SquareShapeRenderer.java
+++ b/MPChartLib/src/com/github/mikephil/charting/renderer/ShapeRenders/SquareShapeRenderer.java
@@ -1,0 +1,75 @@
+package com.github.mikephil.charting.renderer.ShapeRenders;
+
+import android.graphics.Canvas;
+import android.graphics.Paint;
+
+import com.github.mikephil.charting.buffer.ScatterBuffer;
+import com.github.mikephil.charting.interfaces.datasets.IScatterDataSet;
+import com.github.mikephil.charting.utils.ColorTemplate;
+import com.github.mikephil.charting.utils.Utils;
+import com.github.mikephil.charting.utils.ViewPortHandler;
+
+/**
+ * Created by wajdic on 15/06/2016.
+ * Created at Time 09:08
+ */
+public class SquareShapeRenderer implements ShapeRenderer {
+
+
+    @Override
+    public void renderShape(
+            Canvas c, IScatterDataSet dataSet,
+            ViewPortHandler mViewPortHandler, ScatterBuffer buffer, Paint mRenderPaint, final int shapeHoleColor, final float shapeSize) {
+
+        final float shapeHalf = shapeSize / 2f;
+        final float shapeHoleSizeHalf = Utils.convertDpToPixel(dataSet.getScatterShapeHoleRadius());
+        final float shapeHoleSize = shapeHoleSizeHalf * 2.f;
+        final float shapeStrokeSize = (shapeSize - shapeHoleSize) / 2.f;
+        final float shapeStrokeSizeHalf = shapeStrokeSize / 2.f;
+
+        for (int i = 0; i < buffer.size(); i += 2) {
+
+            if (!mViewPortHandler.isInBoundsRight(buffer.buffer[i]))
+                break;
+
+            if (!mViewPortHandler.isInBoundsLeft(buffer.buffer[i])
+                    || !mViewPortHandler.isInBoundsY(buffer.buffer[i + 1]))
+                continue;
+
+            mRenderPaint.setColor(dataSet.getColor(i / 2));
+
+            if (shapeSize > 0.0) {
+                mRenderPaint.setStyle(Paint.Style.STROKE);
+                mRenderPaint.setStrokeWidth(shapeStrokeSize);
+
+                c.drawRect(buffer.buffer[i] - shapeHoleSizeHalf - shapeStrokeSizeHalf,
+                        buffer.buffer[i + 1] - shapeHoleSizeHalf - shapeStrokeSizeHalf,
+                        buffer.buffer[i] + shapeHoleSizeHalf + shapeStrokeSizeHalf,
+                        buffer.buffer[i + 1] + shapeHoleSizeHalf + shapeStrokeSizeHalf,
+                        mRenderPaint);
+
+                if (shapeHoleColor != ColorTemplate.COLOR_NONE) {
+                    mRenderPaint.setStyle(Paint.Style.FILL);
+
+                    mRenderPaint.setColor(shapeHoleColor);
+                    c.drawRect(buffer.buffer[i] - shapeHoleSizeHalf,
+                            buffer.buffer[i + 1] - shapeHoleSizeHalf,
+                            buffer.buffer[i] + shapeHoleSizeHalf,
+                            buffer.buffer[i + 1] + shapeHoleSizeHalf,
+                            mRenderPaint);
+                }
+
+            } else {
+                mRenderPaint.setStyle(Paint.Style.FILL);
+
+                c.drawRect(buffer.buffer[i] - shapeHalf,
+                        buffer.buffer[i + 1] - shapeHalf,
+                        buffer.buffer[i] + shapeHalf,
+                        buffer.buffer[i + 1] + shapeHalf,
+                        mRenderPaint);
+            }
+        }
+    }
+
+
+}

--- a/MPChartLib/src/com/github/mikephil/charting/renderer/ShapeRenders/TriangleShapeRenderer.java
+++ b/MPChartLib/src/com/github/mikephil/charting/renderer/ShapeRenders/TriangleShapeRenderer.java
@@ -1,0 +1,90 @@
+package com.github.mikephil.charting.renderer.ShapeRenders;
+
+import android.graphics.Canvas;
+import android.graphics.Paint;
+import android.graphics.Path;
+
+import com.github.mikephil.charting.buffer.ScatterBuffer;
+import com.github.mikephil.charting.interfaces.datasets.IScatterDataSet;
+import com.github.mikephil.charting.utils.ColorTemplate;
+import com.github.mikephil.charting.utils.Utils;
+import com.github.mikephil.charting.utils.ViewPortHandler;
+
+/**
+ * Created by wajdic on 15/06/2016.
+ * Created at Time 09:08
+ */
+public class TriangleShapeRenderer implements ShapeRenderer {
+
+
+    @Override
+    public void renderShape(
+            Canvas c, IScatterDataSet dataSet,
+            ViewPortHandler mViewPortHandler, ScatterBuffer buffer, Paint mRenderPaint, final int shapeHoleColor, final float shapeSize) {
+
+
+        final float shapeHalf = shapeSize / 2f;
+        final float shapeHoleSizeHalf = Utils.convertDpToPixel(dataSet.getScatterShapeHoleRadius());
+        final float shapeHoleSize = shapeHoleSizeHalf * 2.f;
+        final float shapeStrokeSize = (shapeSize - shapeHoleSize) / 2.f;
+
+
+        mRenderPaint.setStyle(Paint.Style.FILL);
+
+        // create a triangle path
+        Path tri = new Path();
+
+        for (int i = 0; i < buffer.size(); i += 2) {
+
+            if (!mViewPortHandler.isInBoundsRight(buffer.buffer[i]))
+                break;
+
+            if (!mViewPortHandler.isInBoundsLeft(buffer.buffer[i])
+                    || !mViewPortHandler.isInBoundsY(buffer.buffer[i + 1]))
+                continue;
+
+            mRenderPaint.setColor(dataSet.getColor(i / 2));
+
+            tri.moveTo(buffer.buffer[i], buffer.buffer[i + 1] - shapeHalf);
+            tri.lineTo(buffer.buffer[i] + shapeHalf, buffer.buffer[i + 1] + shapeHalf);
+            tri.lineTo(buffer.buffer[i] - shapeHalf, buffer.buffer[i + 1] + shapeHalf);
+
+            if (shapeSize > 0.0) {
+                tri.lineTo(buffer.buffer[i], buffer.buffer[i + 1] - shapeHalf);
+
+                tri.moveTo(buffer.buffer[i] - shapeHalf + shapeStrokeSize,
+                        buffer.buffer[i + 1] + shapeHalf - shapeStrokeSize);
+                tri.lineTo(buffer.buffer[i] + shapeHalf - shapeStrokeSize,
+                        buffer.buffer[i + 1] + shapeHalf - shapeStrokeSize);
+                tri.lineTo(buffer.buffer[i],
+                        buffer.buffer[i + 1] - shapeHalf + shapeStrokeSize);
+                tri.lineTo(buffer.buffer[i] - shapeHalf + shapeStrokeSize,
+                        buffer.buffer[i + 1] + shapeHalf - shapeStrokeSize);
+            }
+
+            tri.close();
+
+            c.drawPath(tri, mRenderPaint);
+            tri.reset();
+
+            if (shapeSize > 0.0 &&
+                    shapeHoleColor != ColorTemplate.COLOR_NONE) {
+
+                mRenderPaint.setColor(shapeHoleColor);
+
+                tri.moveTo(buffer.buffer[i],
+                        buffer.buffer[i + 1] - shapeHalf + shapeStrokeSize);
+                tri.lineTo(buffer.buffer[i] + shapeHalf - shapeStrokeSize,
+                        buffer.buffer[i + 1] + shapeHalf - shapeStrokeSize);
+                tri.lineTo(buffer.buffer[i] - shapeHalf + shapeStrokeSize,
+                        buffer.buffer[i + 1] + shapeHalf - shapeStrokeSize);
+                tri.close();
+
+                c.drawPath(tri, mRenderPaint);
+                tri.reset();
+            }
+        }
+
+    }
+
+}

--- a/MPChartLib/src/com/github/mikephil/charting/renderer/ShapeRenders/XShapeRenderer.java
+++ b/MPChartLib/src/com/github/mikephil/charting/renderer/ShapeRenders/XShapeRenderer.java
@@ -1,0 +1,57 @@
+package com.github.mikephil.charting.renderer.ShapeRenders;
+
+import android.graphics.Canvas;
+import android.graphics.Paint;
+
+import com.github.mikephil.charting.buffer.ScatterBuffer;
+import com.github.mikephil.charting.interfaces.datasets.IScatterDataSet;
+import com.github.mikephil.charting.utils.Utils;
+import com.github.mikephil.charting.utils.ViewPortHandler;
+
+/**
+ * Created by wajdic on 15/06/2016.
+ * Created at Time 09:08
+ */
+public class XShapeRenderer implements ShapeRenderer {
+
+
+    @Override
+    public void renderShape(
+            Canvas c, IScatterDataSet dataSet,
+            ViewPortHandler mViewPortHandler, ScatterBuffer buffer, Paint mRenderPaint, final int shapeHoleColor, final float shapeSize) {
+
+        final float shapeHalf = shapeSize / 2f;
+
+
+
+        mRenderPaint.setStyle(Paint.Style.STROKE);
+        mRenderPaint.setStrokeWidth(Utils.convertDpToPixel(1f));
+
+        for (int i = 0; i < buffer.size(); i += 2) {
+
+            if (!mViewPortHandler.isInBoundsRight(buffer.buffer[i]))
+                break;
+
+            if (!mViewPortHandler.isInBoundsLeft(buffer.buffer[i])
+                    || !mViewPortHandler.isInBoundsY(buffer.buffer[i + 1]))
+                continue;
+
+            mRenderPaint.setColor(dataSet.getColor(i / 2));
+
+            c.drawLine(
+                    buffer.buffer[i] - shapeHalf,
+                    buffer.buffer[i + 1] - shapeHalf,
+                    buffer.buffer[i] + shapeHalf,
+                    buffer.buffer[i + 1] + shapeHalf,
+                    mRenderPaint);
+            c.drawLine(
+                    buffer.buffer[i] + shapeHalf,
+                    buffer.buffer[i + 1] - shapeHalf,
+                    buffer.buffer[i] - shapeHalf,
+                    buffer.buffer[i + 1] + shapeHalf,
+                    mRenderPaint);
+        }
+
+    }
+
+}


### PR DESCRIPTION
Date:   Wed Jun 15 11:30:11 2016 +0100

```
Changing ScatterShape from ENUM to HashMap of String .
Creating a provider which provides ShapeRenderer.
Creating CustomShapeRenderers imlementing ShapeRender with different renderShape() method
Replacing the Switch Statement by ShapeRenderer.renderShape();

=> Better OOP implementation. Scalable easily.
 To add new Shape you only need to create a class implementing ShapeRenderer and override renderShape method and then add the class in the provider ScatterChart.registerShapeRenderer(String scatterShapeName, ShapeRenderer shapeRenderer).
```
